### PR TITLE
feat: add support for OPENAI_API_BASE_PATH and OPENAI_MODEL environment variables

### DIFF
--- a/packages/translator/README.md
+++ b/packages/translator/README.md
@@ -72,14 +72,17 @@ The action would add commit `feat: [AI Generated] translations` to your branch. 
 
 To enable AI translation:
 
-- Setup `process.env.OPENAI_API_KEY`.
+- Setup `process.env.OPENAI_API_KEY`, `process.env.OPENAI_API_BASE_PATH`, `process.env.OPENAI_MODEL`.
 - Create `.env.development` and `.env.production` with:
 
 ```env
 OPENAI_API_KEY=you-api-key # sk-xxxx
+
+OPENAI_API_BASE_PATH=your-api-base-path # optional
+OPENAI_MODEL=your-model # optional
 ```
 
-- Setup `secrets.OPENAI_API_KEY` of your Github repo.
+- Setup `secrets.OPENAI_API_KEY` and others of your Github repo.
 
 ## `ts-intl-translator.config.json`
 

--- a/packages/translator/src/global.d.ts
+++ b/packages/translator/src/global.d.ts
@@ -1,5 +1,7 @@
 declare namespace NodeJS {
   interface ProcessEnv {
     OPENAI_API_KEY: string;
+    OPENAI_API_BASE_PATH: string;
+    OPENAI_MODEL: string;
   }
 }

--- a/packages/translator/src/templates/shared.yml
+++ b/packages/translator/src/templates/shared.yml
@@ -14,6 +14,8 @@ jobs:
 
     env:
       OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+      OPENAI_API_BASE_PATH: ${{ secrets.OPENAI_API_BASE_PATH }}
+      OPENAI_MODEL: ${{ secrets.OPENAI_MODEL }}
 
     steps:
       - uses: actions/checkout@v3

--- a/packages/translator/src/translate.ts
+++ b/packages/translator/src/translate.ts
@@ -10,7 +10,10 @@ import { Translator } from './utils/translator';
 export const translate = async () => {
   setupEnvVariables(parseArgv().env);
 
-  const api = initApi(process.env.OPENAI_API_KEY);
+  const api = initApi(
+    process.env.OPENAI_API_KEY,
+    process.env.OPENAI_API_BASE_PATH,
+  );
 
   const translator = new Translator();
 

--- a/turbo.json
+++ b/turbo.json
@@ -5,7 +5,12 @@
     "build": {
       "dependsOn": ["^build"],
       "outputs": ["dist/**"],
-      "env": ["VSCODE_PID", "OPENAI_API_KEY"]
+      "env": [
+        "VSCODE_PID",
+        "OPENAI_API_KEY",
+        "OPENAI_API_BASE_PATH",
+        "OPENAI_MODEL"
+      ]
     },
     "lint": {
       "outputs": []


### PR DESCRIPTION
This pull request enhances the configurability and flexibility of the AI translation workflow by introducing support for custom OpenAI API base paths and models. It updates environment variable handling across documentation, configuration files, and code to allow users to specify these options both locally and in CI environments.

**Environment variable support and documentation:**
* Updated `packages/translator/README.md` to document new environment variables: `OPENAI_API_BASE_PATH` and `OPENAI_MODEL`, and clarified setup instructions for both local and GitHub secrets.
* Added `OPENAI_API_BASE_PATH` and `OPENAI_MODEL` to the environment variables in the GitHub Actions workflow template (`shared.yml`).
* Updated the `turbo.json` build configuration to include the new environment variables, ensuring they are available during build steps.

**Codebase updates for configurability:**
* Refactored `initApi` in `packages/translator/src/utils/openai.ts` and its usage in `translate.ts` to accept an optional `basePath` parameter, enabling custom API endpoint configuration. [[1]](diffhunk://#diff-cf8f2810070159a1d7c56f0493da89cf598ebb6d99f6f13a8649398e861f359bL6-R33) [[2]](diffhunk://#diff-1f9393381da0329f25fe9b8e60eebd48d7248e6c367faf677ab88b400f41ad01L13-R16)
* Modified the `getCompletion` function to use the `OPENAI_MODEL` environment variable if set, allowing dynamic selection of the OpenAI model at runtime.
* Minor code formatting and consistency improvements for function parameters in `openai.ts`.